### PR TITLE
add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM i386/ubuntu:devel
+
+RUN apt-get -y update
+RUN apt-get install -y libx11-dev \
+	libxext-dev \
+	libc6-dev \
+	gcc
+RUN apt-get install make
+
+COPY . /app
+WORKDIR /app
+
+RUN cd src; make


### PR DESCRIPTION
This installs vx32 into /app (within the container). 
It has been tested to work with 9front: https://github.com/mehlon/tryplan9.