### PR TITLE
all: fix build for gcc version 10

### DIFF
--- a/src/Makefrag
+++ b/src/Makefrag
@@ -1,7 +1,7 @@
 # Main top-level makefile fragment for the vx32 virtual machine.
 
 # Compiler flags common to both host and VX32 environment files.
-COMMON_CFLAGS = -m32  -g -O2 -MD -std=gnu99 -I. -fno-stack-protector $(CFLAGS) -DARCH=i386
+COMMON_CFLAGS = -m32  -g -O2 -MD -std=gnu99 -I. -fno-stack-protector -fcommon $(CFLAGS) -DARCH=i386
 COMMON_LDFLAGS = -g -L. $(LDFLAGS)
 
 ifeq ($(OS),darwin)


### PR DESCRIPTION
gcc 10 defaults to `-fno-common`, which results in a lot of "multiple
definition" errors when linking. As suggested by the gcc documentation,
we workaround the issue for now by setting the `-fcommon` flag:
https://gcc.gnu.org/gcc-10/porting_to.html#common